### PR TITLE
Defined background-color for mod-flair

### DIFF
--- a/StackExchangeDarkMode.user.js
+++ b/StackExchangeDarkMode.user.js
@@ -777,7 +777,9 @@ a.comment-user.owner {
 #review-flowchart svg rect {
     stroke: none;
 }
-
+span.mod-flair {
+    background-color: inherit;
+}
 
 /* Chat */
 .topbar {


### PR DESCRIPTION
Without this, mod OPs writing comments look a little broken: https://i.stack.imgur.com/65oun.png

With this change, there is the tiniest bump on top of the span (https://i.stack.imgur.com/JXJOd.png) but it looks more consistent than before.