### PR TITLE
Answer icons don't get green background

### DIFF
--- a/StackExchangeDarkMode.user.js
+++ b/StackExchangeDarkMode.user.js
@@ -501,7 +501,7 @@ body .bg-yellow-100 {
     background-color: ${bgcolor};
 }
 body .bg-green-400,
-.accepted:not(.icon-q),
+.accepted:not(.icon-q):not(.icon-a),
 .answered-accepted,
 .special-rep {
     background-color: ${darkgreen};


### PR DESCRIPTION
Without this exception, elements that contains the answer icons for accepted questions did get a fully green background like this: https://i.stack.imgur.com/PMV40.png