### PR TITLE
Use DOMParser to produce separate document

### DIFF
--- a/DiscussedOnMeta.user.js
+++ b/DiscussedOnMeta.user.js
@@ -48,7 +48,8 @@
 
             options.method = options.method || 'GET';
             options.onload = function(response) {
-                resolve(response.responseText);
+                let parser = new DOMParser();
+                resolve(parser.parseFromString(response.responseText, 'text/html'));
             };
             options.onerror = function() {
                 reject();

--- a/PostBanDeletedPosts.user.js
+++ b/PostBanDeletedPosts.user.js
@@ -34,7 +34,8 @@
 
             options.method = options.method || 'GET';
             options.onload = function(response) {
-                resolve(response.responseText);
+                let parser = new DOMParser();
+                resolve(parser.parseFromString(response.responseText, 'text/html'));
             };
             options.onerror = function() {
                 reject();


### PR DESCRIPTION
jQuery parses HTML with nested elements (such as a whole page) into a DOM by creating a new div and then setting the `.innerHTML` attribute. Unfortunately, this has side effects; Firefox will pick up the `<link rel="shortcut icon" href="...">` node in the parsed document and change the favicon shown in the tab. This leads to confusing icons for most pages.

This patch changes this to using the [`DOMParser.parseFromString()` API](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#Methods) to parse the HTML into a new owner document before passing the result to jQuery; this separate owner document is not connected to the tab and so won't change the favicon shown.