### PR TITLE
Better rude / chatty comment markup

### DIFF
--- a/CommentFlagsHelper.user.js
+++ b/CommentFlagsHelper.user.js
@@ -75,8 +75,8 @@
 
     function replaceKeywords(jqElem) {
         let text = ' ' + this.innerHTML;
-        text = text.replace(/[*]+/g, ' * ').replace(rudeRegex, ' <span class="cmmt-rude">$1</span>');
-        text = text.replace(/[*]+/g, ' * ').replace(chattyRegex, ' <span class="cmmt-chatty">$1</span>');
+        text = text.replace(/[*]+/g, ' * ').replace(rudeRegex, ' <mark class="cmmt-rude">$1</mark>');
+        text = text.replace(/[*]+/g, ' * ').replace(chattyRegex, ' <mark class="cmmt-chatty">$1</mark>');
         this.innerHTML = text;
     }
 
@@ -764,11 +764,10 @@ table.flagged-posts tr.js-flagged-post:first-child > td {
 }
 .cmmt-rude {
     font-weight: bold;
-    color: red;
+    bottom-border: coral solid 2px;
 }
 .cmmt-chatty {
     font-weight: bold;
-    color: coral;
 }
 
 #actionBtns {

--- a/CommentFlagsHelper.user.js
+++ b/CommentFlagsHelper.user.js
@@ -763,10 +763,12 @@ table.flagged-posts tr.js-flagged-post:first-child > td {
     background: #F48024 !important;
 }
 .cmmt-rude {
+    background-color: var(--orange-200);
+    border-bottom: var(--orange-700) solid 2px;
     font-weight: bold;
-    bottom-border: coral solid 2px;
 }
 .cmmt-chatty {
+    background-color: var(--orange-200);
     font-weight: bold;
 }
 


### PR DESCRIPTION
I found the UX of rude / chatty comments to be very poor, especially at night when f.lux starts shifting towards more red, less blue light.

This update improves this for me, and uses better mark-up. Before:

> ![](https://user-images.githubusercontent.com/46775/76085216-83965280-5fa9-11ea-922b-37ecbd0b0b7b.png)

After:

> ![](https://user-images.githubusercontent.com/46775/76085362-c9ebb180-5fa9-11ea-9af8-bbade839db4d.png)

While the yellow background tends to fade and become less noticeable when the red-shifting kicks in, the bold still stands out, as does the underline on the rude comments. The red text, on the other hand, becomes almost painful to the eye.
