### PR TITLE
Remove background color from inline mod menu.

### DIFF
--- a/AdditionalInlinePostModMenu.user.js
+++ b/AdditionalInlinePostModMenu.user.js
@@ -985,7 +985,6 @@
     padding: 8px 6px 8px;
     font-size: 0.88em;
     line-height: 1;
-    background-color: var(--white);
 }
 
 .js-better-inline-menu .inline-label {


### PR DESCRIPTION
The background color was previously forced to white, which looked fine
on normal posts (which have a white background), but was not correct
on deleted posts (which have a reddish-gray background). I presume
that it would also not be correct when the dark theme is used (although
I haven't tested it). I see no point in explicitly specifying a background
color here; it should just inherit its parent's background color.