### PR TITLE
Tweak appearance of "Load flagger stats" button.

### DIFF
--- a/ModFlaggerStats.user.js
+++ b/ModFlaggerStats.user.js
@@ -202,7 +202,7 @@ unsafeWindow.purgeUserFlagStats = function() {
 
         // Load all flagger stats button
         if(isModPage()) {
-            $('<button id="load-flagger-stats" class="fs-body1">Load flagger stats</button>')
+            $('<button id="load-flagger-stats" class="fs-body1 s-btn s-btn__filled">Load flagger stats</button>')
                 .appendTo('#mainbar-full .fs-body3:first')
                 .click(function() {
                     $(this).remove();


### PR DESCRIPTION
Added the Stacks button styles to the "Load flagger stats" button
in order to make it align and blend in better.

I chose a filled standard button style, not a primary button, to make
the button visible, without being annoying. This is not a primary
button or one that performs an important action.