### PR TITLE
Mark post-banned info div as a post cell

### DIFF
--- a/PostBanDeletedPosts.user.js
+++ b/PostBanDeletedPosts.user.js
@@ -125,7 +125,7 @@
             const rBan = blocked[3].innerText === 'yes';
 
             const banStats = $(`
-              <div class="main-banned">
+              <div class="main-banned postcell post-layout--right">
                 <b>User "${username}" - bans on main: </b>
                 <span>${qBan ? 'question' : ''}</span>
                 <span>${aBan ? 'answer' : ''}</span>


### PR DESCRIPTION
This ensures it is laid out correctly with the rest of the page.

Without this change, the div messes up the layout in Firefox:

![image](https://user-images.githubusercontent.com/46775/93332206-69bbaf00-f819-11ea-9212-6de5b095671b.png)

With the change, the information is properly placed between post and comments:

![image](https://user-images.githubusercontent.com/46775/93332364-a7203c80-f819-11ea-90ec-d9f4c512fd39.png)
