### PR TITLE
Table of contents userscript: fix broken post headings bottom margin

### DIFF
--- a/PostHeadersQuestionToc.user.js
+++ b/PostHeadersQuestionToc.user.js
@@ -655,6 +655,13 @@ a.js-named-anchor {
     color: inherit !important;
 }
 
+/* Keep bottom margin for headings (broken by wrapping them inside an <a> element). */
+.s-prose a.js-named-anchor > h1,
+.s-prose a.js-named-anchor > h2,
+.s-prose a.js-named-anchor > h3 {
+    margin-bottom: revert;
+}
+
 
 /* Move share link to header to save space now that we have the follow button
    Reduce font size slightly


### PR DESCRIPTION
The named anchors functionality is wrapping all headings (`h1`, `h2`, `h3`) in posts inside `a` tags. By doing so, the style defined in [`stacks.css`](https://cdn.sstatic.net/Shared/stacks.css) thinks they are the last children of the post body and therefore sets `margin-bottom: 0;`:

```css
[...] .s-prose h1:last-child, .s-prose h2:last-child, .s-prose h3:last-child, [...] {
    margin-bottom: 0;
}
```

This creates an awkward situation in which headings are way too close to the first following paragraph.

Original:

![image](https://user-images.githubusercontent.com/14198070/110400291-adc89780-8077-11eb-821c-abdd5f283040.png)

With the userscript applied:

![image](https://user-images.githubusercontent.com/14198070/110400231-925d8c80-8077-11eb-9e21-a69201294a10.png)

This commit solves the issue by simply adding a CSS rule to `revert` the style for headings inside `a.js-named-anchor`.

Not sure if I should change the version of the userscript, let me know.