### PR TITLE
Deleted Users Helper: For the user's last IP address, get it from the last line with "IP:"

### DIFF
--- a/DeletedUsersHelper.user.js
+++ b/DeletedUsersHelper.user.js
@@ -311,7 +311,7 @@
         const networkAccountsUrl = `https://stackexchange.com/users/${networkid}?tab=accounts`;
         const modname = details[1].match(/deleted by ([^\(]+)/)[1].trim();
         const modid = details[1].match(/\((\d+)\)/g)[1].replace(/[^\d]+/g, '');
-        const lastip = details[details.length - 2].split(': ')[1];
+        const lastip = details.filter((line) => line.includes('IP:')).reverse()[0].split(': ')[1];
         const reason = details.slice(2, details.length - 2).join('\n').replace('Reason: ', '<b>Reason</b><br>').replace('Detail: ', '<br><b>Additional Details</b><br>').replace(/(https?:\/\/[^\s\)]+)\b/gi, '<a href="$1" target="_blank">$1</a>');
         const delInfo = username != modname ? `deleted on <input value="${deldate}"> by <a href="/users/${modid}" target="_blank">${modname}♦</a>` : `SELF-deleted on <input value="${deldate}">`;
 


### PR DESCRIPTION
The format of the text provided by SE appears to have changed enough such that the line on which the script was assuming the IP address would exist is no longer the correct line. Rather than hard code a specific line, this changes the selection of which line to use to be the last line in the details which includes the text "IP:".