### PR TITLE
WIP: Add ability to send review ban stats to the summary spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/SOMU-options.user.js
+++ b/SOMU-options.user.js
@@ -16,7 +16,6 @@
 // @exclude      https://stackoverflow.com/c/*
 // ==/UserScript==
 
-const store = window.localStorage;
 const toInt = v => v == null || isNaN(Number(v)) ? null : Number(v);
 const toBool = v => v == null ? null : v === true || v.toLowerCase() === 'true';
 const toSlug = str => (str || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
@@ -29,13 +28,14 @@ SOMU = unsafeWindow.SOMU || {
     hasInit: false,
     sidebar: null,
     sidebarContent: null,
+    store: window.localStorage,
 
 
     getOptionValue: function(scriptName, optionName, defaultValue = null, dataType = 'string') {
         const scriptSlug = toSlug(scriptName);
         const optionSlug = toSlug(optionName);
         const uniqueSlug = `${SOMU.keyPrefix}${scriptSlug}:${optionSlug}`;
-        let v = store.getItem(uniqueSlug);
+        let v = this.store.getItem(uniqueSlug);
         if(dataType === 'int') v = toInt(v);
         if(dataType === 'bool') {
             v = toBool(v);
@@ -46,7 +46,7 @@ SOMU = unsafeWindow.SOMU || {
 
 
     saveOptionValue: function(key, value) {
-        store.setItem(key, value.trim());
+        this.store.setItem(key, value.trim());
     },
 
 

--- a/SOMU-options.user.js
+++ b/SOMU-options.user.js
@@ -22,7 +22,7 @@ const toSlug = str => (str || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
 
 // Any way to avoid using a global variable?
-SOMU = unsafeWindow.SOMU || {
+SOMU = unsafeWindow.SOMU || /** @type {SOMU} */ ({
 
     keyPrefix: 'SOMU:',
     hasInit: false,
@@ -30,12 +30,17 @@ SOMU = unsafeWindow.SOMU || {
     sidebarContent: null,
     store: window.localStorage,
 
-
-    getOptionValue: function(scriptName, optionName, defaultValue = null, dataType = 'string') {
+    /**
+     * @param {string} scriptName
+     * @param {string} optionName
+     * @param {string|number|boolean} [defaultValue]
+     * @param {"bool"|"int"|"string"} [dataType]
+     */
+    getOptionValue(scriptName, optionName, defaultValue = null, dataType = 'string') {
         const scriptSlug = toSlug(scriptName);
         const optionSlug = toSlug(optionName);
         const uniqueSlug = `${SOMU.keyPrefix}${scriptSlug}:${optionSlug}`;
-        let v = this.store.getItem(uniqueSlug);
+        let v = /** @type {string|number|boolean} */(this.store.getItem(uniqueSlug));
         if(dataType === 'int') v = toInt(v);
         if(dataType === 'bool') {
             v = toBool(v);
@@ -49,8 +54,13 @@ SOMU = unsafeWindow.SOMU || {
         this.store.setItem(key, value.trim());
     },
 
-
-    addOption: function(scriptName, optionName, defaultValue = '', dataType = 'string') {
+    /**
+     * @param {string} scriptName
+     * @param {string} optionName
+     * @param {string|number|boolean} [defaultValue]
+     * @param {"bool"|"int"|"string"} [dataType]
+     */
+    addOption(scriptName, optionName, defaultValue = '', dataType = 'string') {
         const scriptSlug = toSlug(scriptName);
         const optionSlug = toSlug(optionName);
         const uniqueSlug = `${SOMU.keyPrefix}${scriptSlug}:${optionSlug}`;
@@ -276,7 +286,7 @@ SOMU = unsafeWindow.SOMU || {
     },
 
 
-    init: function() {
+    init() {
 
         // Run validation
         if(typeof jQuery === 'undefined') {
@@ -302,7 +312,7 @@ SOMU = unsafeWindow.SOMU || {
         });
     }
 
-};
+});
 
 
 (function() {

--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -809,23 +809,11 @@
                   'count366': durations.filter(v => v > 365).length
                 };
 
-                const { GreasemonkeyStorage, TampermonkeyStorage } = /** @type {typeof import("@userscripters/store/dist/index")} */(Store);
+                const { locateStorage } = /** @type {typeof import("@userscripters/storage/dist/index")} */(Store);
 
-                const { scriptHandler } = typeof GM !== "undefined" ? GM.info : {};
+                const storage = locateStorage();
 
-                const handlerMap = {
-                    "Greasemonkey": GreasemonkeyStorage,
-                    "Tampermonkey": TampermonkeyStorage
-                };
-
-                const storageConstructor = handlerMap[scriptHandler];
-
-                const store = new Store.default(
-                    "review_ban_helper_sheets_api",
-                    storageConstructor ?
-                        new storageConstructor() :
-                        localStorage
-                );
+                const store = new Store.default("review_ban_helper_sheets_api", storage);
 
                 const sheetsApiVersion = 4;
                 const sheetsApiBase = "https://sheets.googleapis.com";

--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -779,21 +779,16 @@
                     const rowPos = rowIdx + 2;
                     const range = `'Data'!A${rowPos}:V${rowPos}`;
 
-                    if (rowPos > numRows) {
-                        return appendValues(
-                            sheetsApiBase,
-                            sheetsApiVersion,
-                            statsSpreadId,
-                            newData, range
-                        );
-                    }
+                    const handler = rowPos > numRows ? appendValues : updateValues;
 
-                    updateValues(
+                    handler(
                         sheetsApiBase,
                         sheetsApiVersion,
                         statsSpreadId,
                         newData, range
-                    );
+                    ).then(() => {
+                        console.debug("Successful upload");
+                    }, handleError);
                 };
 
                 /**

--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -649,7 +649,7 @@
                   'count366': durations.filter(v => v > 365).length
                 };
 
-                const { GreasemonkeyStorage, TampermonkeyStorage } =/** @type {typeof import("@userscripters/store/dist/index")} */(Store);
+                const { GreasemonkeyStorage, TampermonkeyStorage } = /** @type {typeof import("@userscripters/store/dist/index")} */(Store);
 
                 const { scriptHandler } = typeof GM !== "undefined" ? GM.info : {};
 
@@ -671,7 +671,11 @@
                 const sheetsApiBase = "https://sheets.googleapis.com";
                 const appClientId = await store.load("client_id") || prompt("Enter the Google Cloud Project client id");
                 const statsSpreadId = await store.load("spreadsheet_id") || prompt("Enter the destination spreadsheet id");
-                const sheetsApiKey = await store.load("api_key") || prompt("Enter the Sheets API key");;
+                const sheetsApiKey = await store.load("api_key") || prompt("Enter the Sheets API key");
+
+                await store.save("client_id", appClientId);
+                await store.save("spreadsheet_id", statsSpreadId);
+                await store.save("api_key", sheetsApiKey);
 
                 /**
                  * @param clientId client id to use

--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -25,7 +25,13 @@
 // @include      */admin/links
 //
 // @require      https://raw.githubusercontent.com/samliew/SO-mod-userscripts/master/lib/common.js
+// @require      https://raw.githubusercontent.com/userscripters/storage/master/dist/browser.js
+
+// @grant        GM_setValue
+// @grant        GM_getValue
 // ==/UserScript==
+
+/* globals Store */
 
 (function() {
     'use strict';
@@ -515,7 +521,7 @@
     }
 
 
-    function doPageload() {
+    async function doPageload() {
 
         // New suspend user form
         if(location.pathname === '/admin/review/suspensions/suspend-user') {
@@ -643,11 +649,29 @@
                   'count366': durations.filter(v => v > 365).length
                 };
 
+                const { GreasemonkeyStorage, TampermonkeyStorage } =/** @type {typeof import("@userscripters/store/dist/index")} */(Store);
+
+                const { scriptHandler } = typeof GM !== "undefined" ? GM.info : {};
+
+                const handlerMap = {
+                    "Greasemonkey": GreasemonkeyStorage,
+                    "Tampermonkey": TampermonkeyStorage
+                };
+
+                const storageConstructor = handlerMap[scriptHandler];
+
+                const store = new Store.default(
+                    "review_ban_helper_sheets_api",
+                    storageConstructor ?
+                        new storageConstructor() :
+                        localStorage
+                );
+
                 const sheetsApiVersion = 4;
                 const sheetsApiBase = "https://sheets.googleapis.com";
-                const sheetsApiKey = "";
-                const appClientId = "";
-                const statsSpreadId = "";
+                const appClientId = await store.load("client_id") || prompt("Enter the Google Cloud Project client id");
+                const statsSpreadId = await store.load("spreadsheet_id") || prompt("Enter the destination spreadsheet id");
+                const sheetsApiKey = await store.load("api_key") || prompt("Enter the Sheets API key");;
 
                 /**
                  * @param clientId client id to use

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,33 @@
+type OptionType = "string"|"int"|"bool";
+type OptionValueType = string|number|boolean;
+
+interface SOMU {
+    keyPrefix: string,
+    hasInit: boolean,
+    sidebar: JQuery | null,
+    sidebarContent: JQuery | null,
+    store: Storage;
+
+    addOption(scriptName: string, optionName: string, defaultValue?: boolean, dataType?: "bool"): boolean | undefined;
+    addOption(scriptName: string, optionName: string, defaultValue?: number, dataType?: "int"): boolean | undefined;
+    addOption(scriptName: string, optionName: string, defaultValue?: string, dataType?: "string"): boolean | undefined;
+    addOption(scriptName: string, optionName: string, defaultValue?: string, dataType?: OptionType): boolean | undefined;
+
+    appendStyles(): void;
+    handleSidebarEvents(): void;
+
+    getOptionValue(scriptName: string, optionName: string, defaultValue?: boolean, dataType?: "bool"): boolean;
+    getOptionValue(scriptName: string, optionName: string, defaultValue?: number, dataType?: "int"): number;
+    getOptionValue(scriptName: string, optionName: string, defaultValue?: string, dataType?: "string"): string;
+    getOptionValue(scriptName: string, optionName: string, defaultValue?: OptionValueType, dataType?: OptionType): OptionValueType;
+
+    saveOptionValue(key: string, value: string): void;
+
+    init(): void;
+}
+
+declare var SOMU: SOMU;
+
+interface Window {
+    SOMU: SOMU | undefined;
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "checkJs": true,
+        "allowJs": true,
+        "types": ["jquery","tampermonkey","./globals"]
+    },
+    "include": ["./SOMU-*"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,9 @@
     "": {
       "devDependencies": {
         "@types/gapi": "^0.0.41",
-        "@types/gapi.auth2": "^0.0.55"
+        "@types/gapi.auth2": "^0.0.55",
+        "@types/greasemonkey": "^4.0.2",
+        "@types/tampermonkey": "^4.0.5"
       }
     },
     "node_modules/@types/gapi": {
@@ -23,6 +25,18 @@
       "dependencies": {
         "@types/gapi": "*"
       }
+    },
+    "node_modules/@types/greasemonkey": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
+      "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "node_modules/@types/tampermonkey": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
+      "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
+      "dev": true
     }
   },
   "dependencies": {
@@ -40,6 +54,18 @@
       "requires": {
         "@types/gapi": "*"
       }
+    },
+    "@types/greasemonkey": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
+      "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "@types/tampermonkey": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tampermonkey/-/tampermonkey-4.0.5.tgz",
+      "integrity": "sha512-FGPo7d+qZkDF7vyrwY1WNhcUnfDyVpt2uyL7krAu3WKCUMCfIUzOuvt8aSk8N2axHT8XPr9stAEDGVHLvag6Pw==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "SO-mod-userscripts",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/gapi": "^0.0.41",
+        "@types/gapi.auth2": "^0.0.55"
+      }
+    },
+    "node_modules/@types/gapi": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.41.tgz",
+      "integrity": "sha512-tmHO66z/f91JZCDqinj/nNvQEszsz/hBT4+MvCSKT5sDzl5Ld/oXZ8WaecCBjRLw2uWKUInUHM9MhEXWkOiNjw==",
+      "dev": true
+    },
+    "node_modules/@types/gapi.auth2": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@types/gapi.auth2/-/gapi.auth2-0.0.55.tgz",
+      "integrity": "sha512-chmROsbo28jI5or0aRP8X3aBuWkq8jJHj75al/C0BhI/qum8v7XSxxQ9aLpA2ULPWgWSyh6orn9ZCaUSA4iQCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/gapi": "*"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/gapi": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/gapi/-/gapi-0.0.41.tgz",
+      "integrity": "sha512-tmHO66z/f91JZCDqinj/nNvQEszsz/hBT4+MvCSKT5sDzl5Ld/oXZ8WaecCBjRLw2uWKUInUHM9MhEXWkOiNjw==",
+      "dev": true
+    },
+    "@types/gapi.auth2": {
+      "version": "0.0.55",
+      "resolved": "https://registry.npmjs.org/@types/gapi.auth2/-/gapi.auth2-0.0.55.tgz",
+      "integrity": "sha512-chmROsbo28jI5or0aRP8X3aBuWkq8jJHj75al/C0BhI/qum8v7XSxxQ9aLpA2ULPWgWSyh6orn9ZCaUSA4iQCA==",
+      "dev": true,
+      "requires": {
+        "@types/gapi": "*"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
         "@types/gapi": "^0.0.41",
         "@types/gapi.auth2": "^0.0.55",
         "@types/greasemonkey": "^4.0.2",
+        "@types/jquery": "^3.5.11",
         "@types/tampermonkey": "^4.0.5"
       }
     },
@@ -30,6 +31,21 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
       "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.11.tgz",
+      "integrity": "sha512-lYZGdfOtUa0XFjIATQgiogqeTY5PNNMOmp3Jq48ghmJALL8t/IqABRqlEwdHfuUdA8iIE1uGD1HoI4a7Tiy6OA==",
+      "dev": true,
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
     },
     "node_modules/@types/tampermonkey": {
@@ -59,6 +75,21 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/greasemonkey/-/greasemonkey-4.0.2.tgz",
       "integrity": "sha512-aCdl08liJA/GaT5xH8bhqbGCG6HCRU/jqs3QuJcMOsSxBDgbiif3LVLI7AF7FekPN3XxGevRHSw7ov8ITKf4Hw==",
+      "dev": true
+    },
+    "@types/jquery": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.11.tgz",
+      "integrity": "sha512-lYZGdfOtUa0XFjIATQgiogqeTY5PNNMOmp3Jq48ghmJALL8t/IqABRqlEwdHfuUdA8iIE1uGD1HoI4a7Tiy6OA==",
+      "dev": true,
+      "requires": {
+        "@types/sizzle": "*"
+      }
+    },
+    "@types/sizzle": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
+      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
       "dev": true
     },
     "@types/tampermonkey": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "@types/gapi": "^0.0.41",
+    "@types/gapi.auth2": "^0.0.55"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "devDependencies": {
     "@types/gapi": "^0.0.41",
-    "@types/gapi.auth2": "^0.0.55"
+    "@types/gapi.auth2": "^0.0.55",
+    "@types/greasemonkey": "^4.0.2",
+    "@types/tampermonkey": "^4.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@types/gapi": "^0.0.41",
     "@types/gapi.auth2": "^0.0.55",
     "@types/greasemonkey": "^4.0.2",
+    "@types/jquery": "^3.5.11",
     "@types/tampermonkey": "^4.0.5"
   }
 }


### PR DESCRIPTION
This PR adds support for sending review ban stats to the summary spreadsheet via the userscript.

For the update to work, the production version has to create a Google Cloud Project and set 3 variables (required by Google):

```typescript
const sheetsApiKey = ""; // API key created on https://console.cloud.google.com/apis/credentials
const appClientId = ""; // OAuth 2.0 Client IDs created on https://console.cloud.google.com/apis/credentials
const statsSpreadId = ""; // spreadsheet id, i.e. 1GIH-6CH58lJbQ18vPcsrBVzlHwjOmuYTxktMbLV9TWk
```

A potential caveat is that the `https://www.googleapis.com/auth/spreadsheets` (read/write) scope requested from the user can be quite scary for security-conscious users, but there is no other way around for allowing writes to a spreadsheet on behalf of a user (no, unfortunately, the scope cannot be "scoped"). That said, the authorization is incremental (i.e. does not happen until the user actually tries to perform the action), so should not disrupt the normal flow of the userscript.