### PR TITLE
DeletedUsersHelper: Remove spurious newlines

### DIFF
--- a/DeletedUsersHelper.user.js
+++ b/DeletedUsersHelper.user.js
@@ -189,7 +189,7 @@ function initDeleteUserHelper() {
             const uid = Number(settings.url.match(/\/admin\/users\/(\d+)\//)[1]);
 
             getUserPii(uid).then(v => {
-                const userDetails = `\n\nEmail:     ${v.email}\nReal Name: ${v.name}`;
+                const userDetails = `Email:     ${v.email}\nReal Name: ${v.name}`;
                 const deleteReasonDetails = userDetails;
                 $('#deleteReasonDetails, #destroyReasonDetails').val('\n\n' + userDetails);
             });


### PR DESCRIPTION
The `userDetails` text is added to the text box with 4 newline characters, because when creating the variable the text starts with two newlines, and then another 2 are added two lines down. Remove the first 2 of these.