### PR TITLE
SOMU-options SOMU global fix

### DIFF
--- a/SOMU-options.user.js
+++ b/SOMU-options.user.js
@@ -3,7 +3,8 @@
 // @description  Adds right sidebar to modify options of installed userscripts from the Stack Overflow Moderation Userscripts repo
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      2.3
+// @version      2.3.1
+// @grant        unsafeWindow
 //
 // @include      https://*stackoverflow.com/*
 // @include      https://*serverfault.com/*
@@ -31,7 +32,7 @@ const toSlug = str => (str || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
 
 
 // Any way to avoid using a global variable?
-var SOMU = unsafeWindow.SOMU || /** @type {SOMU} */ ({
+unsafeWindow.SOMU = unsafeWindow.SOMU || /** @type {SOMU} */ ({
 
     keyPrefix: 'SOMU:',
     hasInit: false,
@@ -322,6 +323,3 @@ var SOMU = unsafeWindow.SOMU || /** @type {SOMU} */ ({
 });
 
 SOMU.init();
-
-// For testing purposes
-// SOMU.addOption('Test Script', 'Testing Option', 'default value');

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,12 +1,12 @@
-type OptionType = "string"|"int"|"bool";
-type OptionValueType = string|number|boolean;
+type OptionType = "string" | "int" | "bool";
+type OptionValueType = string | number | boolean;
 
 interface SOMU {
     keyPrefix: string,
     hasInit: boolean,
     sidebar: JQuery | null,
     sidebarContent: JQuery | null,
-    store: Storage | import("@userscripters/storage").AsyncStorage
+    store: Storage | import("@userscripters/storage").AsyncStorage;
 
     addOption(scriptName: string, optionName: string, defaultValue?: boolean, dataType?: "bool"): boolean | undefined;
     addOption(scriptName: string, optionName: string, defaultValue?: number, dataType?: "int"): boolean | undefined;
@@ -29,14 +29,16 @@ interface SOMU {
 declare var SOMU: SOMU;
 declare var Store: typeof import("@userscripters/storage");
 
-declare function ajaxPromise(opts: string|object, type?: string): Promise<Document>;
+declare function ajaxPromise(opts: string | object, type?: string): Promise<Document>;
 declare function isModerator(): boolean;
 declare function hasInvalidIds(): boolean;
-declare function htmlDecode(input:string): string;
+declare function htmlDecode(input: string): string;
 declare function jQueryXhrOverride(): XMLHttpRequest;
-declare function addBackoff(sec:number): void;
+declare function addBackoff(sec: number): void;
 
 interface Window {
+    jQuery: JQueryStatic;
+    $: JQueryStatic;
     SOMU: SOMU | undefined;
     Store: typeof Store | undefined;
 }


### PR DESCRIPTION
This PR fixes the `SOMU` global initialization as `var SOMU = ...` is not able to escape the sandboxed `window`.
It also explicitly grants access to `unsafeWindow` via a `@grant` header (previously implied).
As a minor addition to the PR come improvements to shared typings and a bit of formatting.