### PR TITLE
Do not auto-sort by rank

### DIFF
--- a/NotAnAnswerFlagQueueHelper.user.js
+++ b/NotAnAnswerFlagQueueHelper.user.js
@@ -477,7 +477,7 @@ function listenToPageUpdates() {
 
         // Flagger stats loaded, allow sorting by
         if (settings.url.includes('/users/flag-summary/')) {
-            $('#flag-queue-tabs #flagger-rank').removeClass('dno').click();
+            $('#flag-queue-tabs #flagger-rank').removeClass('dno');
         }
     });
 }


### PR DESCRIPTION
This reverts 473be9f38bb54a2b732e6e32476a29463afb199d; this change is *amazingly* annoying:

- the re-sort happens at an unspecified time after loading a flag page. It regularly causes a post I was already interacting with to move, and then I have to search for it again.
- I can't pick any other another sort option, as that *triggers a page load*, so flagger ranking is loaded again, and the page is resorted.

Please leave this a manual choice.

Can I suggest that if you feel strongly about this sort option being the default for you, that we make this a preference? Perhaps store the last selected sort option and use that on page load.