### PR TITLE
Fix undefined and unsafeWindow refs

### DIFF
--- a/10kToolsHelper.user.js
+++ b/10kToolsHelper.user.js
@@ -18,7 +18,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.$ = unsafeWindow.jQuery;
 }
 

--- a/ChatImprovements.user.js
+++ b/ChatImprovements.user.js
@@ -25,9 +25,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 

--- a/ChatMoreMagicLinks.user.js
+++ b/ChatMoreMagicLinks.user.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ChatTranscriptsByDefault.user.js
+++ b/ChatTranscriptsByDefault.user.js
@@ -24,7 +24,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/CommentFlagTypeColours.user.js
+++ b/CommentFlagTypeColours.user.js
@@ -44,7 +44,7 @@ e/ ==UserScript==
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/CommentFlagTypeColours.user.js
+++ b/CommentFlagTypeColours.user.js
@@ -1,4 +1,4 @@
-e/ ==UserScript==
+// ==UserScript==
 // @name         Comment Flag Type Colours
 // @description  Background colours for each comment flag type
 // @homepage     https://github.com/samliew/SO-mod-userscripts

--- a/CommentFlagsHelper.user.js
+++ b/CommentFlagsHelper.user.js
@@ -34,7 +34,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/CommentUserColours.user.js
+++ b/CommentUserColours.user.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/DeclinedFlagsNotifier.user.js
+++ b/DeclinedFlagsNotifier.user.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/DisplayInlineCommentFlagHistory.user.js
+++ b/DisplayInlineCommentFlagHistory.user.js
@@ -24,7 +24,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/DownvotePostsInSearchResults.user.js
+++ b/DownvotePostsInSearchResults.user.js
@@ -25,7 +25,7 @@
 // Run only when search results has filter for "not locked" posts
 if (!/locked%3a(no|0)/.test(location.search)) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/DuplicateAnswersFlagsHelper.user.js
+++ b/DuplicateAnswersFlagsHelper.user.js
@@ -25,7 +25,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ElectionSupporterFlairs.user.js
+++ b/ElectionSupporterFlairs.user.js
@@ -23,9 +23,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 const store = window.localStorage;

--- a/ExpandShortLinks.user.js
+++ b/ExpandShortLinks.user.js
@@ -17,7 +17,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/HideReputation.user.js
+++ b/HideReputation.user.js
@@ -23,7 +23,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/HideVoteCounts.user.js
+++ b/HideVoteCounts.user.js
@@ -28,7 +28,7 @@
 // If rep is too low, do nothing. Rep for guests is 0, so this covers not logged-in users.
 if (StackExchange.options.user.rep < 125) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/HoverExpandNavigationLinks.user.js
+++ b/HoverExpandNavigationLinks.user.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/LightboxImages.user.js
+++ b/LightboxImages.user.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/MobileModeratorPages.user.js
+++ b/MobileModeratorPages.user.js
@@ -25,7 +25,7 @@ const isModPage = () => document.body.classList.contains('mod-page');
 
 if (!isMobile() || !isModPage()) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ModBatchCommentDeleter.user.js
+++ b/ModBatchCommentDeleter.user.js
@@ -17,7 +17,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ModFlaggerStats.user.js
+++ b/ModFlaggerStats.user.js
@@ -28,9 +28,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 const superusers = [584192];

--- a/ModPopupDialogImprovements.user.js
+++ b/ModPopupDialogImprovements.user.js
@@ -29,7 +29,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ModUserQuicklinksEverywhere.user.js
+++ b/ModUserQuicklinksEverywhere.user.js
@@ -23,7 +23,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ModeratorHistoryImprovements.user.js
+++ b/ModeratorHistoryImprovements.user.js
@@ -12,7 +12,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/NoOneboxesInChat.user.js
+++ b/NoOneboxesInChat.user.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/NoOneboxesInChatTranscripts.user.js
+++ b/NoOneboxesInChatTranscripts.user.js
@@ -18,9 +18,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 /* Call hideOneboxes() from other scripts to hide all new oneboxes on any page update

--- a/NoUserIdShareLinks.user.js
+++ b/NoUserIdShareLinks.user.js
@@ -17,7 +17,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/NotAnAnswerFlagQueueHelper.user.js
+++ b/NotAnAnswerFlagQueueHelper.user.js
@@ -23,7 +23,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/PossibleVandalismCommentDeletionsHelper.user.js
+++ b/PossibleVandalismCommentDeletionsHelper.user.js
@@ -20,7 +20,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/PossibleVandalismDeletionsHelper.user.js
+++ b/PossibleVandalismDeletionsHelper.user.js
@@ -23,7 +23,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/PossibleVandalismEditsHelper.user.js
+++ b/PossibleVandalismEditsHelper.user.js
@@ -20,7 +20,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/PostTimelineFilters.user.js
+++ b/PostTimelineFilters.user.js
@@ -24,7 +24,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/RedactedScreenshots.user.js
+++ b/RedactedScreenshots.user.js
@@ -19,7 +19,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/RefreshEmptyModQueue.user.js
+++ b/RefreshEmptyModQueue.user.js
@@ -20,9 +20,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 const goToMain = () => location.href = '/admin/dashboard?filtered=false';

--- a/RevertTooltips.user.js
+++ b/RevertTooltips.user.js
@@ -21,7 +21,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -35,7 +35,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/SOMU-options.user.js
+++ b/SOMU-options.user.js
@@ -21,9 +21,11 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
+} else {
+    unsafeWindow = window;
 }
 
 const toInt = v => v == null || isNaN(Number(v)) ? null : Number(v);

--- a/SearchbarNavImprovements.user.js
+++ b/SearchbarNavImprovements.user.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/ShowDeletedMessagesInChat.user.js
+++ b/ShowDeletedMessagesInChat.user.js
@@ -22,7 +22,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/StackPrintStyles.user.js
+++ b/StackPrintStyles.user.js
@@ -25,7 +25,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/SuspiciousVotingHelper.user.js
+++ b/SuspiciousVotingHelper.user.js
@@ -23,7 +23,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/TooManyCommentsFlagQueueHelper.user.js
+++ b/TooManyCommentsFlagQueueHelper.user.js
@@ -20,7 +20,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/UserHistoryImprovements.user.js
+++ b/UserHistoryImprovements.user.js
@@ -17,7 +17,7 @@
 
 'use strict';
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/UserSocialMediaProfileLinks.user.js
+++ b/UserSocialMediaProfileLinks.user.js
@@ -22,7 +22,7 @@
 // Moderator check
 if (typeof StackExchange == "undefined" || !StackExchange.options || !StackExchange.options.user || !StackExchange.options.user.isModerator) return;
 
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }

--- a/lib/common.js
+++ b/lib/common.js
@@ -8,7 +8,7 @@
 
 // make jQuery available when running in a userscript sandbox
 // See https://github.com/samliew/SO-mod-userscripts/issues/112
-if (unsafeWindow !== undefined && window !== unsafeWindow) {
+if (typeof unsafeWindow !== 'undefined' && window !== unsafeWindow) {
     window.jQuery = unsafeWindow.jQuery;
     window.$ = unsafeWindow.jQuery;
 }


### PR DESCRIPTION
This is needed for Mobile Safari (with Userscript extension), where undefined
variables can throw an exception unless `typeof` is used, and where there is to
`unsafeWindow`.
