### PR TITLE
Avoid false positives in short usernames regex

### DIFF
--- a/ReduceClutter.user.js
+++ b/ReduceClutter.user.js
@@ -450,7 +450,7 @@ function initShortUsernames() {
             .filter((i, el) => el.children.length === 0)
             .addClass('js-shortusernames').text((i, v) => {
                 return v.trim()
-                    .replace(/[\s-_]+(-|_|says|wants|likes|loves|supports|has|is|is.at|stands|reinstate)[\s-_]*.+$/i, '');
+                    .replace(/[\s-_]+(-|_|says|wants|likes|loves|supports|has|is|stands|reinstate)[\s-_].+$/i, '');
             });
     }
 


### PR DESCRIPTION
Remove zero-or-more (`*`) quantifier from closing `[\s-_]` group; with the
quantifier any element past the first that *starts* with one of the words (such
as *islam* or *haspero* or *lovelace*) would be removed as there are zero
spaces, dashes or underscores past the letters matched before this group.

Remove the `is.at` alternative, it matches too broadly; there are loads of valid
second names with *is* LETTER *mat*. Names with *is at* are already matched by
the *is* alternative..
