### PR TITLE
Do not load RQH on /review page

### DIFF
--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -5,12 +5,12 @@
 // @author       @samliew
 // @version      4.6
 //
-// @include      https://*stackoverflow.com/review*
-// @include      https://*serverfault.com/review*
-// @include      https://*superuser.com/review*
-// @include      https://*askubuntu.com/review*
-// @include      https://*mathoverflow.net/review*
-// @include      https://*.stackexchange.com/review*
+// @include      https://*stackoverflow.com/review/*
+// @include      https://*serverfault.com/review/*
+// @include      https://*superuser.com/review/*
+// @include      https://*askubuntu.com/review/*
+// @include      https://*mathoverflow.net/review/*
+// @include      https://*.stackexchange.com/review/*
 //
 // @include      https://*stackoverflow.com/questions/*
 // @include      https://*serverfault.com/questions/*

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Keyboard shortcuts, skips accepted questions and audits (to save review quota)
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      4.6
+// @version      4.7
 //
 // @include      https://*stackoverflow.com/review/*
 // @include      https://*serverfault.com/review/*


### PR DESCRIPTION
RQH is not designed to work on the main `/review` page, however, the permissive `/review*` match allows it to run there, causing it to error out when fetching flags quota in `getFlagsQuota`. This PR restricts `@include` headers to review-specific pages.