### PR TITLE
Fix search selectors

### DIFF
--- a/PostBanDeletedPosts.user.js
+++ b/PostBanDeletedPosts.user.js
@@ -137,12 +137,12 @@ function doPageLoad() {
             if (isNaN(count) || count <= 0) return;
 
             // Add deleted posts to the stats element
-            const results = $('.search-results .search-result, .js-search-results .search-result', data);
+            const results = $('.search-results .search-result, .js-search-results .s-card', data);
             stats.find('.meta-mentions').append(results);
 
             // Add copyable element to the results
             const hyperlinks = results.find('a').attr('href', (i, v) => 'https://' + mainDomain + v).attr('target', '_blank');
-            const hyperlinks2 = hyperlinks.filter('.question-hyperlink').map((i, el) => `[${1 + i}](${toShortLink(el.href)})`).get();
+            const hyperlinks2 = hyperlinks.filter('.s-link[data-searchsession^="/"],.answer-hyperlink').map((i, el) => `[${1 + i}](${toShortLink(el.href)})`).get();
             const comment = `Deleted ${type}${hyperlinks2.length == 1 ? '' : 's'}, score <= 0, contributing to the [${type} ban](https://${location.hostname}/help/${type}-bans): ${hyperlinks2.join(' ')}`;
             const commentArea = $(`<textarea readonly="readonly"></textarea>`).val(comment).appendTo(stats);
 

--- a/PostBanDeletedPosts.user.js
+++ b/PostBanDeletedPosts.user.js
@@ -3,7 +3,7 @@
 // @description  When user posts on SO Meta regarding a post ban, fetch and display deleted posts (must be mod) and provide easy way to copy the results into a comment
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      3.2
+// @version      3.3
 //
 // @include      https://meta.stackoverflow.com/questions/*
 //


### PR DESCRIPTION
**Type of change**
- [X] Bugfix
- [ ] New feature

**Pre-review checklist**
- [x] I have commented my code
- [x] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**

SO updated the search selectors again. Highlights:

* `.question-hyperlink` no longer exists
* `.answer-hyperlink` is now a thing
* `.s-link` with a data selector gets questions; just `.s-link` may be enough
* `.search-result` is no longer a thing either; replaced with `.s-card`. Didn't touch the first selector because I have no idea what context it's used in.
* And to add insult to injury, two selectors are now required for the filter, because while `.s-link` is applied to question links, answers have `.answer-hyperlink`, and there's no overlap beyond the data attribute, but relying on it entirely doesn't feel like a great idea

A test on both question and answer bans indicates this should work, but feel free to test more first for good measure
