### PR TITLE
only insert 'follow' button if the native button is missing

### DIFF
--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Keyboard shortcuts, skips accepted questions and audits (to save review quota)
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      4.8
+// @version      4.9
 //
 // @include      https://*stackoverflow.com/review/*
 // @include      https://*serverfault.com/review/*
@@ -1259,8 +1259,10 @@ function listenToPageUpdates() {
                         }
                     }
 
-                    // follow
-                    postmenu.prepend(`<button data-pid="${pid}" data-post-type="${isQuestion ? 'question' : 'answer'}" class="js-somu-follow-post s-btn s-btn__link fc-black-400 h:fc-black-700 pb2" role="button">follow</button>`);
+                    // if following feature is missing, add our own
+                    if(!document.getElementById(`btnFollowPost-${pid}`)) {
+                        postmenu.prepend(`<button data-pid="${pid}" data-post-type="${isQuestion ? 'question' : 'answer'}" class="js-somu-follow-post s-btn s-btn__link fc-black-400 h:fc-black-700 pb2" role="button">follow</button>`);
+                    }
 
                     // edit
                     if (queueType !== 'suggested-edits') {


### PR DESCRIPTION
**Type of change**
- [X] Bugfix
- [ ] New feature

**Pre-review checklist**
- [x] I have commented my code
- [x] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**

Unconditionally appending our own version of "follow" causes the button to appear twice (and in an incorrect state) since SE fixed that too. This PR makes RHQ look up the follow button and only append the custom one if not present.

![ice_screenshot_20220518-212332](https://user-images.githubusercontent.com/34833340/169118529-ca833467-e2aa-4ef4-b092-d52d85b012a5.png)
