### PR TITLE
Dawn of the living stats & toasts

### DIFF
--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -29,6 +29,14 @@
 // @exclude      *chat.*
 // @exclude      https://stackoverflow.com/c/*
 // @exclude      https://stackoverflow.blog*
+//
+// @exclude      https://*stackoverflow.com/review/*/stats
+// @exclude      https://*serverfault.com/review/*/stats
+// @exclude      https://*superuser.com/review/*/stats
+// @exclude      https://*askubuntu.com/review/*/stats
+// @exclude      https://*mathoverflow.net/review/*/stats
+// @exclude      https://*.stackexchange.com/review/*/stats
+//
 // ==/UserScript==
 
 /* globals StackExchange */

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -125,6 +125,30 @@ function getFlagsQuota(viewablePostId = 1) {
             .fail(reject);
     });
 }
+
+/**
+ * @summary builds a post summary stats item
+ * @param {...(string | Node)} content
+ * @returns {HTMLElement}
+ */
+const makePostSummaryItem = (...content) => {
+    const wrapper = document.createElement("div");
+    wrapper.classList.add("s-post-summary--stats-item");
+    wrapper.append(...content);
+    return wrapper;
+};
+
+/**
+ * @param {string} text
+ * @param {...string} classes
+ */
+const makeIndicator = (text, ...classes) => {
+    const wrapper = document.createElement("span");
+    wrapper.classList.add("bounty-indicator-tab", ...classes);
+    wrapper.textContent = text;
+    return wrapper;
+};
+
 async function displayRemainingQuota() {
 
     // Ignore mods, since we have unlimited power
@@ -150,15 +174,17 @@ async function displayRemainingQuota() {
     // Clear old values
     $('.remaining-quota').remove();
 
-    // Display number of CVs and flags remaining
-    const quota = $(`<table class="remaining-quota"><tr><td colspan="2">
-                  <span class="remaining-votes"><span class="bounty-indicator-tab">${remainingCloseVotes}</span> <span>close votes left</span></span>
-                </td></tr>
-                <tr><td colspan="2">
-                  <span class="flag-remaining-inform" style="padding-right:20px"><span class="bounty-indicator-tab supernovabg">${remainingPostFlags}</span> flags left</span>
-                </td></tr></table>`);
+    const postStats = document.querySelector(".s-post-summary--stats");
+    if(!postStats) {
+        console.debug(`[${scriptName}] missing post stats`);
+        return;
+    }
 
-    $('.reviewable-post-stats > table').after(quota);
+    // Display number of CVs and flags remaining
+    postStats.append(
+        makePostSummaryItem(makeIndicator(remainingCloseVotes), " close votes left"),
+        makePostSummaryItem(makeIndicator(remainingPostFlags, "supernovabg"), " flags left")
+    );
 }
 
 
@@ -859,9 +885,6 @@ function doPageLoad() {
 
     // Add additional class to body based on review queue
     document.body.classList.add(queueType + '-review-queue');
-
-    // Display remaining CV and flag quota for non-mods
-    setTimeout(displayRemainingQuota, 3000);
 
     // Detect queue type and set appropriate process function
     switch (queueType) {

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Keyboard shortcuts, skips accepted questions and audits (to save review quota)
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      4.11
+// @version      4.12
 //
 // @include      https://*stackoverflow.com/review/*
 // @include      https://*serverfault.com/review/*
@@ -1173,6 +1173,10 @@ function listenToPageUpdates() {
                     $('.js-review-actions button[title*="done reviewing"]').click();
                 }, 1000);
             }
+
+            // display "flag" and "close" buttons
+            const hiddenMenuItems = document.querySelectorAll(".js-post-menu .flex--item.d-none");
+            hiddenMenuItems.forEach((item) => item.classList.remove("d-none"));
 
             // If reviewing a suggested edit from Q&A (outside of review queues)
             if (location.href.includes('/questions/')) {

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Keyboard shortcuts, skips accepted questions and audits (to save review quota)
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      4.10
+// @version      4.11
 //
 // @include      https://*stackoverflow.com/review/*
 // @include      https://*serverfault.com/review/*
@@ -242,26 +242,41 @@ function loadOptions() {
 
 
 let toastTimeout, defaultDuration = 2;
-function toastMessage(msg, duration = defaultDuration) {
+
+/**
+ * @summary displays a toast message
+ * @param {string} msg message text
+ * @param {number} [durationSeconds] for how long to show it (seconds)
+ * @returns {void}
+ */
+const toastMessage = (msg, durationSeconds = defaultDuration) => {
+    const toast = document.getElementById("toasty");
+    if(!toast) {
+        const newToast = document.createElement("div");
+        newToast.id = "toasty";
+        newToast.textContent = msg;
+        document.body.append(newToast);
+        return toastMessage(msg, durationSeconds);
+    }
+
     // Validation
-    duration = Number(duration);
+    durationSeconds = Number(durationSeconds);
     if (typeof (msg) !== 'string') return;
-    if (isNaN(duration)) duration = defaultDuration;
+    if (isNaN(durationSeconds)) durationSeconds = defaultDuration;
 
     // Clear existing timeout
     if (toastTimeout) clearTimeout(toastTimeout);
 
-    // Reuse or create new
-    let div = $('#toasty').html(msg).show();
-    if (div.length == 0) div = $(`<div id="toasty">${msg}</div>`).appendTo(document.body);
+    // update toast message
+    toast.textContent = msg;
+
+    $(toast).show();
 
     // Log in browser console as well
-    console.log(msg);
+    console.debug(`[${scriptName}] ${msg}`);
 
     // Hide div
-    toastTimeout = setTimeout(function (div) {
-        div.hide();
-    }, duration * 1000, div);
+    toastTimeout = setTimeout(() => $(toast).hide(), durationSeconds * 1000);
 }
 
 
@@ -543,7 +558,7 @@ function processReopenReview() {
     }
     // Question has some edits with no bad images, ignore
     else if ((subs > 200 || adds > 200) && badImageLinks === 0) {
-        toastMessage('skipping minor edits', 3000);
+        toastMessage('skipping minor edits', 3);
         setTimeout(skipReview, 4000);
         return;
     }
@@ -1397,7 +1412,7 @@ function listenToPageUpdates() {
                         skipReview();
                     }
                     else {
-                        toastMessage('this is a review audit', 10000);
+                        toastMessage('this is a review audit', 5);
                     }
 
                     return;

--- a/ReviewQueueHelper.user.js
+++ b/ReviewQueueHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Keyboard shortcuts, skips accepted questions and audits (to save review quota)
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      4.9
+// @version      4.10
 //
 // @include      https://*stackoverflow.com/review/*
 // @include      https://*serverfault.com/review/*


### PR DESCRIPTION
**Type of change**
- [X] Bugfix

**Pre-review checklist**
- [X] I have commented my code
- [X] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**

This PR revives the daily flag and close vote quota stats broken by SE's rework of the queues:

![ice_screenshot_20220521-170120](https://user-images.githubusercontent.com/34833340/169655079-4c14aaef-fd43-4dc8-8da6-82e9d7eba4ca.png)

This includes:

- a rework of how remaining daily quota is fetched to make it less brittle (as it broke on MSO, unfortunately)
- exclusion of /stats pages as those cause the quota fetch to err out
- a rewiring of the quota stats elements to the new review UI
- a fix for audit toasts (turns out, the `duration` parameter was in seconds, not ms)
- some minor linting (semicolons, spaces, and all that jazz)
 
Styling adjustments to be included in later updates.
