### PR TITLE
Add moderator stats

### DIFF
--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Display users' prior review bans in review, Insert review ban button in user review ban history page, Load ban form for user if user ID passed via hash
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      8.2
+// @version      8.3
 //
 // @include      */review/close*
 // @include      */review/reopen*
@@ -828,7 +828,24 @@ async function doPageLoad() {
         const pastWeek = rows.filter((i, el) => new Date(el.children[1].children[0].title) > weekAgo).length;
         const unbanDay = rows.filter((i, el) => el.children[2].innerText.match(/(just|min|hour)/)).length;
         const unbanWeek = rows.filter((i, el) => new Date(el.children[2].children[0].title) < weekAhead).length;
+        const banners = rows.map((i, el) => el.children[4].children[0].innerText);
+      
+        const totalBans = rows.length;
+      
+        let bannerMap = {};
+        
+        for (let username of banners) {
+            bannerMap[username] = (bannerMap[username] + 1) || 1;
+        }
 
+        let bannerHtml = "<div><br>Mod stats:<br><ul>";
+        for (let [username, count] of Object.entries(bannerMap)) {
+            bannerHtml += `<li>${username}: ${count} (${(count / totalBans * 100.0).toFixed(2)}%)</li>`;
+        }
+        bannerHtml += "</ul></div>";
+      
+        const bannerStats = $(bannerHtml);
+      
         const durations = rows.map((i, el) => Number(el.children[3].innerText)).get();
         const tally = {
             'count4': durations.filter(v => v <= 4).length,
@@ -891,11 +908,15 @@ Breakdown:<br>
 <td class="pl4">${tally.count365}</td>
 <td class="pl4">${tally.count366}</td>
 </tr></table>`);
+      
+      
 
         // Add a table that we can copy into a spreadsheet
         if (isSuperuser) {
             copyTable.appendTo(bannedStats);
         }
+      
+        bannerStats.appendTo(bannedStats);
 
         table.before(bannedStats);
         bannedStats.prepend(`<span>Currently, there are ${rows.length} banned reviewers, out of which:</span>`).parent().addClass('banned-reviewers-section');

--- a/UserReviewBanHelper.user.js
+++ b/UserReviewBanHelper.user.js
@@ -828,12 +828,13 @@ async function doPageLoad() {
         const pastWeek = rows.filter((i, el) => new Date(el.children[1].children[0].title) > weekAgo).length;
         const unbanDay = rows.filter((i, el) => el.children[2].innerText.match(/(just|min|hour)/)).length;
         const unbanWeek = rows.filter((i, el) => new Date(el.children[2].children[0].title) < weekAhead).length;
+        
+        // Grab constant stats; the usernames of the reviewers (without the "Bot" label or the diamond), plus the length for stats
         const banners = rows.map((i, el) => el.children[4].children[0].innerText);
-      
         const totalBans = rows.length;
       
+        // Count elements
         let bannerMap = {};
-        
         for (let username of banners) {
             bannerMap[username] = (bannerMap[username] + 1) || 1;
         }
@@ -844,6 +845,7 @@ async function doPageLoad() {
         }
         bannerHtml += "</ul></div>";
       
+        // This gets added to the end of bannedStats, after copyTable if it's loaded
         const bannerStats = $(bannerHtml);
       
         const durations = rows.map((i, el) => Number(el.children[3].innerText)).get();


### PR DESCRIPTION
**Type of change**
- [ ] Bugfix
- [X] New feature

**Pre-review checklist**
- [X] I have commented my code
- [X] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**

- Adds a nice little table with a breakdown of mods
  ![Image showing a list of four mods (well, three and community) with their respective ban counts, and a percentage](https://user-images.githubusercontent.com/29489988/181834282-3c6065ef-8dcf-4143-964c-71d21b0e9307.png)

  These have not been hooked up into the spreadsheet, because I don't see much use for it aside checking how many mods are looking at reviews at any given time. I imagine these are better used internally anyway
