### PR TITLE
Add "demands to show effort/'not a code-writing service'", "promotional content; answers not self-contained", and "generic year-long ban" templates

### DIFF
--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -65,6 +65,30 @@ Flagging as spam is much more expedient than voting to close, and actually allow
 Thank you for your attention to this matter in the future. If you have any questions, please let us know!`
     },
     {
+        templateName: "promotional content; answers not self-contained",
+        suspensionReason: "for promotional content",
+        suspensionDefaultDays: 0,
+        templateBody: `**Promotional content:**  
+We noticed that at least some of your posts seem to promote and/or link to a product, website, blog, library, YouTube channel/videos, project, source code repository, etc. Per the [help center](https://stackoverflow.com/help/behavior):
+
+> Be careful, because the community frowns on overt self-promotion and tends to vote it down and flag it as spam. Post good, relevant answers, and if some (but not all) happen to be about your product or website, so be it. However, you _must_ disclose your affiliation in your answers. Also, if a huge percentage of your posts include a mention of your product or website, you're probably here for the wrong reasons. Our advertising rates are quite reasonable; [contact our ad sales team for details](https://stackoverflow.com/advertising).
+
+You should also review the content at the following links:
+
+- [**What signifies "Good" self promotion?**](https://meta.stackexchange.com/q/182212),
+- [some tips and advice about self-promotion](https://stackoverflow.com/help/promotion),
+- [What is the exact definition of "spam" for Stack Overflow?](https://meta.stackoverflow.com/q/260638), and
+- [What makes something spam](https://meta.stackexchange.com/a/58035).
+
+Any type of "astroturfing" promotion is not acceptable, regardless of if it's for profit or not. It brings down the overall value of genuine content and recommendations for everyone on the site.
+
+If you do include a link to something, then the link needs to be directly relevant to the question and/or answer (i.e. a specific page that is about the issue(s) in the question and/or answer). It should not be just a general link to your site, product, blog, YouTube channel, etc. If the link is to something you are affiliated with, then you _must_ include explicit disclosure of your affiliation in your post, unless the link is to official documentation for a product/library that is explicitly asked about in the question.
+
+**Answers must be a self-contained answer to the question:**  
+Your answers need to be actual, complete answers to the question. Just a link to something off-site doesn't make for an answer. [Answers must actually answer the question](https://meta.stackexchange.com/q/225370), without requiring the user to click to some other site to get enough information to solve the problem / answer the question. Please [add context around links](https://meta.stackoverflow.com/a/8259). _[Always quote](https://stackoverflow.com/help/referencing) the most relevant part of an important link, in case the target site is unreachable or goes permanently offline._ If you are linking to a library or framework, then [explain _why_ and _how_ it solves the problem, _and provide code on how to use it_](https://meta.stackoverflow.com/a/251605). Take into account that being _barely more than a link to an external site_ is a reason as to [Why and how are some answers deleted?](https://stackoverflow.com/help/deleted-answers).
+`
+    },
+    {
         templateName: "soliciting votes",
         suspensionReason: "for rule violations",
         suspensionDefaultDays: 0,
@@ -159,6 +183,29 @@ Since this suspension is fully voluntary, you are welcome to reply to this messa
 
 We wish you a pleasant vacation from the site, and we look forward to your return!`,
         addSuffix: false,
+    },
+    {
+        templateName: "demands to show effort/\"not a code-writing service\"",
+        suspensionReason: "for rule violations",
+        suspensionDefaultDays: 0,
+        templateBody: `It has come to our attention that you've left one or more comments similar to the following:
+
+> 
+
+[Stack Overflow *is* a code-writing service](https://meta.stackoverflow.com/a/408565), in the sense that it is a programming Q&A site, and most questions here are solved by writing code in the answer. It is [not a debugging helpdesk for askers](https://meta.stackexchange.com/a/364585)&mdash;we do not require that askers provide existing code to debug. Lack of problem-solving effort is not a reason to close or otherwise object to questions. [The only type of effort we require is the effort required to ask a clear, focused, non-duplicate question](https://meta.stackoverflow.com/a/260909). Including an attempt often adds noise and results in answers that are applicable to just the original asker, rather than anyone doing the same thing.  Many of the most useful questions on the site do not include an existing attempt at solving the problem.
+
+Of course, Stack Overflow is *also* not a free application design and development service. Questions may still be closed as too broad (or unclear) if that is the problem. But please do not try to limit the questions asked here to problems with *existing* code. Instead, focus on the scope and clarity of questions. The goal should be to encourage questions that might help the next person with the same problem.
+
+Please do not post any more of these comments. They add noise for moderators to remove, may be perceived as demanding or unfriendly, and don't assist with our goal of creating a knowledge base.`,
+    },
+    {
+        templateName: "generic year-long ban",
+        suspensionReason: "for rule violations",
+        suspensionDefaultDays: 365,
+        templateBody: `Account removed for spamming and/or abusive behavior. You\'re no longer welcome to participate here.`,
+        addPrefix: false,
+        addSuffix: false,
+        addSignature: false
     },
     /* EXAMPLE
     {


### PR DESCRIPTION
The "demands to show effort/'not a code-writing service'" template was
written by me.

"promotional content; answers not self-contained" was written by Makyen,
and is used with permission.

"generic year-long ban" is the same message used by
AdditionalInlinePostModMenu that is designed to fit within the notification
seen by a recreated account.
