### PR TITLE
Reduce Mod Message Helper display impact when not adding menu

### DIFF
--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -940,6 +940,17 @@ function appendModMessageMenu() {
 </a>`);
 
         });
+        // If we didn't add an actual mod message link, then remove the js-mod-message-menu class.
+        $('.js-mod-message-menu')
+            .filter(function() {return $(this).find('.js-mod-message-link').length === 0;})
+            .removeClass('js-mod-message-menu');
+        // Let CSS know that the .user-action-time is blank
+        $('.js-mod-message-menu .user-action-time')
+            .filter(function() {
+                const $this = $(this);
+                return $this.children().length === 0 && $this.text().trim().length === 0;
+            })
+            .addClass('user-action-time-is-blank');
 
     // Show menu on click only
     if (modMenuOnClick) {
@@ -989,34 +1000,37 @@ doPageLoad();
 const styles = document.createElement('style');
 styles.setAttribute('data-somu', GM_info?.script.name);
 styles.innerHTML = `
-.user-info,
-.s-user-card {
+.user-info.js-mod-message-menu,
+.s-user-card.js-mod-message-menu {
     position: relative;
     border: 1px solid transparent;
 }
-.user-info,
+.user-info.js-mod-message-menu,
     min-height: 88px;
 }
-.user-info:hover,
-.s-user-card:hover {
+.user-info.js-mod-message-menu:hover,
+.s-user-card.js-mod-message-menu:hover {
     /*border-color: var(--black-200);*/
 }
 .user-info.js-mod-message-menu:not(.js-mod-quicklinks):not(.s-topbar--item),
 .s-user-card.js-mod-message-menu:not(.js-mod-quicklinks):not(.s-topbar--item):not(.s-user-card__minimal) {
     padding-bottom: 25px;
 }
-.user-action-time {
+.js-mod-message-menu .user-action-time {
     min-height: 15px;
 }
+.js-mod-message-menu .user-action-time.user-action-time-is-blank {
+    display: none;
+}
 
-.mod-summary .user-info,
-.mod-summary .s-user-card,
-.mod-summary .user-action-time,
-.single-badge-user .user-info,
-.single-badge-user .s-user-card,
-.single-badge-user .user-action-time,
-.cast-votes .user-info,
-.cast-votes .s-user-card {
+.mod-summary .user-info.js-mod-message-menu,
+.mod-summary .s-user-card.js-mod-message-menu,
+.mod-summary .js-mod-message-menu .user-action-time,
+.single-badge-user .user-info.js-mod-message-menu,
+.single-badge-user .s-user-card.js-mod-message-menu,
+.single-badge-user .js-mod-message-menu .user-action-time,
+.cast-votes .user-info.js-mod-message-menu,
+.cast-votes .s-user-card.js-mod-message-menu {
     min-height: 0;
 }
 

--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Adds menu to quickly send mod messages to users
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      3.3.1
+// @version      3.3.2
 //
 // @match        *://*.askubuntu.com/*
 // @match        *://*.mathoverflow.net/*


### PR DESCRIPTION
**Type of change**
- [X] Bugfix
- [ ] New feature

**Pre-review checklist**
- [X] I have commented my code
- [X] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**
Reduce display impact when not adding menu

This PR:
1. Removes the js-mod-message-menu class when there isn't a .js-mod-message-link descendant.
2. Not display the .js-mod-message-menu .user-action-time when the .user-action-time is blank
3. Requires the .js-mod-message-menu class to be present to apply some CSS to descendants.

**Is this feature/update deployment associated with any issues?**

Closes #150 
