### PR TITLE
MMH: prevent double signature

### DIFF
--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -54,7 +54,7 @@ const modMenuOnClick = true;
  * This may be edited to add more custom templates to mod messages.
  * addPrefix false:    no pleasantries and userlink
  * addSuffix false:    no suspension auto message
- * addSignature false: no regards and sign off
+ * addSignature true:  Add regards and sign off. SE now adds this by default.
  * soOnly true:        Only use the template on Stack Overflow
  * sendEmail false:    Don't send email to the user.
  *
@@ -795,7 +795,7 @@ function escapeText(text) {
 
 function generateCmOrModMessageTemplate(isCmMessage, item, i, numberOfItems, messagePrefix, messageSuffix, messageSignature="") {
     const templateNumber = numberOfItems + i;
-    const templateBodyText = (item.addPrefix !== false ? messagePrefix : '') + item.templateBody + (item.addSuffix !== false ? messageSuffix : '') + (item.addSignature !== false ? messageSignature : '');
+    const templateBodyText = (item.addPrefix !== false ? messagePrefix : '') + item.templateBody + (item.addSuffix !== false ? messageSuffix : '') + (item.addSignature === true ? messageSignature : '');
     const templateBodyProcessed = escapeText(templateBodyText);
     const templateShortText = item.templateBody.length > 400 ? item.templateBody.replace(/(\n|\r)+/g, ' ').substr(0, 397) + '...' : item.templateBody;
     const templateSuspensionReason = escapeText(item.suspensionReason || '');

--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Adds menu to quickly send mod messages to users
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      3.3.2
+// @version      3.3.3
 //
 // @match        *://*.askubuntu.com/*
 // @match        *://*.mathoverflow.net/*


### PR DESCRIPTION
**Type of change**
- [X] Bugfix
- [ ] New feature

**Pre-review checklist**
- [X] I have commented my code
- [X] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**
SE has changed to separately adding the signature to the resulting text, rather than have the signature embedded in the text for each mod message option. Thus, if we include the signature in the text for the template options which are being added, there end up being two copies of the signature.

This just changes the logic so we only add the (extra) signature when the template has `addSignature: true`. Given that no template has that defined, we don't add an additional signature.

We should probably look at being able to remove the signature which SE adds when `addSignature: false` is in the template,
but that's not implemented at this time, as this is just a minimal quick change to prevent having two signatures in mod messages. Alternately, just not having the `addSignature` option.

**Is this feature/update deployment associated with any issues?**
No.

Closes #
