### PR TITLE
MMH: Prevent somu-mod-message-menu from opening off-screen (left/right)

### DIFF
--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -996,8 +996,23 @@ function appendModMessageMenu() {
             $('.somu-mod-message-link.active').removeClass('active');
         });
         $('.js-mod-message-menu').on('click', '.somu-mod-message-link', function (evt) {
-            $(this).addClass('active');
+            const $this = $(this);
+            $this.addClass('active');
             evt.stopPropagation();
+            const menu = $this.find('.somu-mod-message-menu');
+            const menuRect = menu[0].getBoundingClientRect();
+            const menuLeftPosition = menuRect.left;
+            if (menuLeftPosition < 0) {
+                // The menu is currently off the viewport to the left, so adjust it to be inside.
+                const menuCssLeftPx = Number((menu.css('left').match(/\d+/) || [0])[0]);
+                menu.css('left', `calc(${menuCssLeftPx - menuLeftPosition}px + 1vw)`);
+            }
+            const menuRightPosition = menuRect.right;
+            if (menuRightPosition > window.innerWidth) {
+                // The menu is currently off the viewport to the right, so adjust it to be inside.
+                const menuCssLeftPx = Number((menu.css('left').match(/\d+/) || [0])[0]);
+                menu.css('left', `calc(${menuCssLeftPx - (menuRightPosition - window.innerWidth)}px - 1vw)`);
+            }
         });
     }
 }
@@ -1126,6 +1141,7 @@ styles.innerHTML = `
 
     user-select: none;
     white-space: nowrap;
+    max-width: 98vw;
 }
 #somu-mod-message-menu {
     background: var(--white) !important;

--- a/ModMessageHelper.user.js
+++ b/ModMessageHelper.user.js
@@ -3,7 +3,7 @@
 // @description  Adds menu to quickly send mod messages to users
 // @homepage     https://github.com/samliew/SO-mod-userscripts
 // @author       @samliew
-// @version      3.4.0
+// @version      3.4.1
 //
 // @match        *://*.askubuntu.com/*
 // @match        *://*.mathoverflow.net/*


### PR DESCRIPTION
**Type of change**
- [X] Bugfix
- [ ] New feature

**Pre-review checklist**
- [X] I have commented my code
- [X] I have bumped the minor version of the changed userscript(s)

**Brief description of the change:**

- Prevent the somu-mod-message-menu menu from being off-screen upon opening, which could happen at some screen widths.

**Is this feature/update deployment associated with any issues?**

No.
